### PR TITLE
Fix long a

### DIFF
--- a/content/_partners/partner-project-buddhist-art.md
+++ b/content/_partners/partner-project-buddhist-art.md
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: LOD Methodologies in Gandhāran Buddhist Art and Texts
+title: LOD Methodologies in Gandhāran Buddhist Art and Texts
 partner-url: 
 category: [semantic annotation, gazetteers]
 logo: /assets/images/partners/Partner_Gandahar.jpg
 ---
 
-Connecting specialists to develop Linked Data methodologies for the study of Gandhāran art 
+Connecting specialists to develop Linked Data methodologies for the study of Gandhāran art 
 and Buddhism.


### PR DESCRIPTION
I replaced the long a in “Gandhāran” with a textual variant that renders better on the final page. (Yes, it looks weird in the GitHub preview, but it should be fine on the final site.)