### PR TITLE
Remove scheme from url

### DIFF
--- a/content/_partners/partner-project-PeriodO.md
+++ b/content/_partners/partner-project-PeriodO.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: PeriodO
-partner-url: http://perio.do/
+partner-url: perio.do
 category: [ collaboration, gazetteers, visualisation, semantic annotation ]
 logo: /assets/images/partners/Partner_PeriodO.png
 ---


### PR DESCRIPTION
The link from https://pelagios.org/partners/ to PeriodO is broken; this should fix it.