### PR TITLE
black death digital archive partner materials added

### DIFF
--- a/partners.html
+++ b/partners.html
@@ -17,14 +17,14 @@ permalink: /partners/
   
   <a href="https://globalmiddleages.org/project/black-death-digital-archive-project">
     {% if partner.logo != nil %}
-      <img class="partner-logo" src="{{ partner.logo }}"  />
+      <img class="partner-logo" src="https://drive.google.com/open?id=0B909A3riMKrHSGpFaEZVeDFfX0hCRzJTSmpob0JQcGFoNE5R"  />
     {% endif %}
       <h2>{{ partner.title }}</h2>
       <p>{{ partner.content }}</p>
     </a>
     {% else %}
     {% if partner.logo != nil %}
-    <img class="partner-logo" src="{{ partner.logo }}"  />
+    <img class="partner-logo" src="https://drive.google.com/open?id=0B909A3riMKrHSGpFaEZVeDFfX0hCRzJTSmpob0JQcGFoNE5R"  />
   {% endif %}
     <h2>Black Death Digital Archive</h2>
     <p>The Black Death Digital Archive (BDDA) is a multidisciplinary portal for researching the Second Plague Pandemic, i.e., outbreaks of plague that started with the mid-fourteenth-century Black Death and their recurrences across Afro-Eurasia during six hundred years, from the 1340s to 1940s.</p>

--- a/partners.html
+++ b/partners.html
@@ -15,7 +15,7 @@ permalink: /partners/
 <div class="partner">
   {% if partner.partner-url != nil %}
   
-  <a href="http://{{ partner.partner-url }}">
+  <a href="https://globalmiddleages.org/project/black-death-digital-archive-project">
     {% if partner.logo != nil %}
       <img class="partner-logo" src="{{ partner.logo }}"  />
     {% endif %}
@@ -26,8 +26,8 @@ permalink: /partners/
     {% if partner.logo != nil %}
     <img class="partner-logo" src="{{ partner.logo }}"  />
   {% endif %}
-    <h2>{{ partner.title }}</h2>
-    <p>{{ partner.content }}</p>
+    <h2>Black Death Digital Archive</h2>
+    <p>The Black Death Digital Archive (BDDA) is a multidisciplinary portal for researching the Second Plague Pandemic, i.e., outbreaks of plague that started with the mid-fourteenth-century Black Death and their recurrences across Afro-Eurasia during six hundred years, from the 1340s to 1940s.</p>
   {% endif %}
  </div>
 {% endfor %}


### PR DESCRIPTION
Hi Bekka,

Not sure if google docs are accessible as logo. else we use the common pelagios logo.
image: https://www.bl.uk/manuscripts/Viewer.aspx?ref=royal_ms_6_e_vi!1_f267v

 Blurb: The Black Death Digital Archive (BDDA) is a multidisciplinary portal for researching the Second Plague Pandemic, i.e., outbreaks of plague that started with the mid-fourteenth-century Black Death and their recurrences across Afro-Eurasia during six hundred years, from the 1340s to 1940s.