### PR TITLE
Fixed link to nodegoat.net

### DIFF
--- a/content/_partners/partner-project-nodegoat.md
+++ b/content/_partners/partner-project-nodegoat.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: nodegoat
-partner-url: https://nodegoat.net
+partner-url: nodegoat.net
 category: [collaboration, gazetteers]
 logo: /assets/images/partners/Partner_nodegoat.png
 ---


### PR DESCRIPTION
### The issue

The link to the nodegoat project on the Pelagios partner page is broken because the `partner-url` front matter item for the nodegoat partner post contained `https://`, but there's a protocol in the layout template too, so it's duplicated in the page.

### What this PR does

Removes the protocol from the `partner-url` front matter item for the nodegoat partner post, so that the link works.

 